### PR TITLE
4 : Adding factory_bot and Faker done

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 3.7'
+
+  # Custom 
+  gem "factory_bot_rails", "~> 4.0"
+  gem install faker
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development, :test do
 
   # Custom 
   gem "factory_bot_rails", "~> 4.0"
-  gem install faker
+  gem 'faker'
 end
 
 group :development do


### PR DESCRIPTION
1. `gem "factory_bot_rails", "~> 4.0" `
2. Add the below text in a new file ` spec/support/factory_bot.rb` :
``` 
RSpec.configure do |config|
  config.include FactoryBot::Syntax::Methods
end 
```
3. ` gem faker `
To use faker : ` require 'faker' `