### PR TITLE
Issue06 creation lesson model

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --color
 --require spec_helper
 --require rails_helper
+--format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -27,11 +27,13 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'rspec-rails', '~> 3.7'
+end
 
-  # Custom
+group :test do
   gem "factory_bot_rails", "~> 4.0"
   gem 'faker'
+  gem 'rspec-rails', '~> 3.7'
+  gem 'shoulda-matchers', '~> 3.1'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,8 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    shoulda-matchers (3.1.2)
+      activesupport (>= 4.0.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -189,6 +191,7 @@ DEPENDENCIES
   relaxed-rubocop
   rspec-rails (~> 3.7)
   rubocop (~> 0.57.2)
+  shoulda-matchers (~> 3.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: lessons
+#
+#  id          :uuid             not null, primary key
+#  title       :string(50)       not null
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+class Lesson < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 50 }
+  validates :description, length: { maximum: 300 }
+end

--- a/db/migrate/20180707143159_create_lessons.rb
+++ b/db/migrate/20180707143159_create_lessons.rb
@@ -1,0 +1,10 @@
+class CreateLessons < ActiveRecord::Migration[5.2]
+  def change
+    create_table :lessons, id: :uuid do |t|
+      t.string :title, limit: 50, null: false
+      t.text :description, limit: 300
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_06_083756) do
+ActiveRecord::Schema.define(version: 2018_07_07_143159) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "lessons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "title", limit: 50, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
 end

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -1,0 +1,19 @@
+# == Schema Information
+#
+# Table name: lessons
+#
+#  id          :uuid             not null, primary key
+#  title       :string(50)       not null
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+require 'faker'
+
+FactoryBot.define do
+  factory :lesson do
+    title Faker::Hacker.noun
+    description Faker::ChuckNorris.fact
+  end
+end

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -13,7 +13,7 @@ require 'faker'
 
 FactoryBot.define do
   factory :lesson do
-    title Faker::Hacker.noun
-    description Faker::ChuckNorris.fact
+    title Faker::Hacker.noun.first(50)
+    description Faker::ChuckNorris.fact.first(300)
   end
 end

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -1,0 +1,38 @@
+# == Schema Information
+#
+# Table name: lessons
+#
+#  id          :uuid             not null, primary key
+#  title       :string(50)       not null
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+require 'rails_helper'
+
+RSpec.describe Lesson, type: :model do
+  it "is valid with valid attributes" do
+    expect(build(:lesson)).to be_valid
+  end
+
+  it "is valid with no description" do
+    expect(build(:lesson, description: "")).to be_valid
+  end
+
+  it "is saved with valid attributes" do
+    expect { create(:lesson) }.to change { Lesson.count }.by(1)
+  end
+
+  it "is invalid with no title" do
+    expect(build(:lesson, title: "")).to be_invalid
+  end
+
+  it "is invalid with so long title" do
+    expect(build(:lesson, title: Faker::Lorem.characters(51))).to be_invalid
+  end
+
+  it "is invalid with so long description" do
+    expect(build(:lesson, description: Faker::Lorem.characters(301))).to be_invalid
+  end
+end

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -35,4 +35,11 @@ RSpec.describe Lesson, type: :model do
   it "is invalid with so long description" do
     expect(build(:lesson, description: Faker::Lorem.characters(301))).to be_invalid
   end
+
+  # With shoulda
+  # Same result that "is invalid without title"
+  it { should validate_presence_of(:title) }
+
+  # Same result that "is invalid with so long description"
+  it { should validate_length_of(:description).is_at_most(300) }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path('../config/environment', __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'support/factory_bot'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,3 +56,17 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    # Choose a test framework:
+    with.test_framework :rspec
+
+    # Choose one or more libraries:
+    # with.library :active_record
+    # with.library :active_model
+    # with.library :action_controller
+    # Or, choose the following (which implies all of the above):
+    with.library :rails
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,14 +59,7 @@ end
 
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
-    # Choose a test framework:
     with.test_framework :rspec
-
-    # Choose one or more libraries:
-    # with.library :active_record
-    # with.library :active_model
-    # with.library :action_controller
-    # Or, choose the following (which implies all of the above):
     with.library :rails
   end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
# Migration : 
Command : `rails generate model lesson title:string{50} description:text{300}`
We can't define a parameter "can't be empty" with command line. 
Then in migrate file : 
``` 
t.string :title, limit: 50, null:false
t.text :description, limit: 300 
```
# Validation 
In lesson model file :
```
validates :title, presence: true, length: { maximum: 50 }
validates :description, length: { maximum: 300 }
```

# Test
### Factory : 
```
require 'faker'

FactoryBot.define do
  factory :lesson do
    title Faker::Hacker.noun
    description Faker::ChuckNorris.fact
  end
end
```

### Creation and validation :
Creation and save test with expect and factory_bot.
*With factory_bot, `build` builds an instance of object. `create` saves and persists it.*    
```
it "is valid with valid attributes" do
    expect(build(:lesson)).to be_valid
  end
```

Some tests are rewritten with should gem : 
```
it { should validate_presence_of(:title) }
```


closes #6 