### PR TITLE
Issue09 lesson controller

### DIFF
--- a/.rubocop-https---relaxed-ruby-style-rubocop-yml
+++ b/.rubocop-https---relaxed-ruby-style-rubocop-yml
@@ -1,0 +1,166 @@
+# Relaxed.Ruby.Style
+## Version 2.2
+
+Style/Alias:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylealias
+
+Style/AsciiComments:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#styleasciicomments
+
+Style/BeginBlock:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylebeginblock
+
+Style/BlockDelimiters:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#styleblockdelimiters
+
+Style/CommentAnnotation:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylecommentannotation
+
+Style/Documentation:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#styledocumentation
+
+Layout/DotPosition:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#layoutdotposition
+
+Style/DoubleNegation:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#styledoublenegation
+
+Style/EndBlock:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#styleendblock
+
+Style/FormatString:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#styleformatstring
+
+Style/IfUnlessModifier:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#styleifunlessmodifier
+
+Style/Lambda:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylelambda
+
+Style/ModuleFunction:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylemodulefunction
+
+Style/MultilineBlockChain:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylemultilineblockchain
+
+Style/NegatedIf:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylenegatedif
+
+Style/NegatedWhile:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylenegatedwhile
+
+Style/ParallelAssignment:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#styleparallelassignment
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylepercentliteraldelimiters
+
+Style/PerlBackrefs:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#styleperlbackrefs
+
+Style/Semicolon:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylesemicolon
+
+Style/SignalException:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylesignalexception
+
+Style/SingleLineBlockParams:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylesinglelineblockparams
+
+Style/SingleLineMethods:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylesinglelinemethods
+
+Layout/SpaceBeforeBlockBraces:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#layoutspacebeforeblockbraces
+
+Layout/SpaceInsideParens:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#layoutspaceinsideparens
+
+Style/SpecialGlobalVars:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylespecialglobalvars
+
+Style/StringLiterals:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylestringliterals
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#styletrailingcommainarguments
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#styletrailingcommainarrayliteral
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#styletrailingcommainhashliteral
+
+Style/WhileUntilModifier:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylewhileuntilmodifier
+
+Style/WordArray:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#stylewordarray
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#lintambiguousregexpliteral
+
+Lint/AssignmentInCondition:
+  Enabled: false
+  StyleGuide: https://relaxed.ruby.style/#lintassignmentincondition
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockNesting:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
-inherit_gem:
-  relaxed-rubocop: .rubocop.yml
+inherit_from:
+- https://relaxed.ruby.style/rubocop.yml
 
 AllCops:
   DisplayStyleGuide: true

--- a/Gemfile
+++ b/Gemfile
@@ -54,3 +54,6 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 # Gem for rubocop
 gem "relaxed-rubocop"
 gem 'rubocop', '~> 0.57.2', require: false
+
+# Serializer
+gem 'active_model_serializers', '~> 0.10.0'

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development do
 
   # Custom
   gem 'annotate'
+  gem 'pry'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -28,14 +28,13 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'puma'
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem "factory_bot_rails", "~> 4.0"
+  gem 'faker'
+  gem 'pry-byebug'
+  gem 'rspec-rails', '~> 3.7'
 end
 
 group :test do
-  gem "factory_bot_rails", "~> 4.0"
-  gem 'faker'
-  gem 'rspec-rails', '~> 3.7'
   gem 'shoulda-matchers', '~> 3.1'
 end
 
@@ -47,7 +46,6 @@ group :development do
 
   # Custom
   gem 'annotate'
-  gem 'pry'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,6 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 # Custom :
 # Gem for rubocop
-gem "relaxed-rubocop"
 gem 'rubocop', '~> 0.57.2', require: false
 
 # Serializer

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
+gem 'puma'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
     byebug (10.0.2)
     case_transform (0.2)
       activesupport
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     diff-lcs (1.3)
@@ -101,6 +102,9 @@ GEM
       ast (~> 2.4.0)
     pg (1.0.0)
     powerpack (0.1.2)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rack (2.0.5)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -196,6 +200,7 @@ DEPENDENCIES
   faker
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
+  pry
   rails (~> 5.2.0)
   relaxed-rubocop
   rspec-rails (~> 3.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,9 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     puma (3.12.0)
     rack (2.0.5)
     rack-test (1.0.0)
@@ -196,12 +199,11 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   annotate
   bootsnap (>= 1.1.0)
-  byebug
   factory_bot_rails (~> 4.0)
   faker
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
-  pry
+  pry-byebug
   puma
   rails (~> 5.2.0)
   relaxed-rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.7)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.2.0)
       activesupport (= 5.2.0)
       globalid (>= 0.3.6)
@@ -51,6 +56,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
+    case_transform (0.2)
+      activesupport
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     diff-lcs (1.3)
@@ -68,6 +75,7 @@ GEM
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.1)
+    jsonapi-renderer (0.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -180,6 +188,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   annotate
   bootsnap (>= 1.1.0)
   byebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    relaxed-rubocop (2.3.1)
     rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -206,7 +205,6 @@ DEPENDENCIES
   pry-byebug
   puma
   rails (~> 5.2.0)
-  relaxed-rubocop
   rspec-rails (~> 3.7)
   rubocop (~> 0.57.2)
   shoulda-matchers (~> 3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    puma (3.12.0)
     rack (2.0.5)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -201,6 +202,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry
+  puma
   rails (~> 5.2.0)
   relaxed-rubocop
   rspec-rails (~> 3.7)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,3 @@
-# README
+# Postman documentation
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+The postman documentation is [here](https://documenter.getpostman.com/view/4861262/RWMCvVoX).

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,17 @@
 class ApplicationController < ActionController::API
-  rescue_from ActiveRecord::RecordInvalid, ActionController::ParameterMissing, with: :show_errors_403
-  rescue_from ActiveRecord::RecordNotFound, with: :show_errors_404
+  rescue_from ActiveRecord::RecordInvalid, with: :rescue_bad_params
+  rescue_from ActionController::ParameterMissing, with: :rescue_param_missing
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
-  def show_errors_403(exception)
-    render json: exception, status: :forbidden
+  def rescue_bad_params(exception)
+    render json: { error: exception.record.errors.full_messages }, status: :forbidden
   end
 
-  def show_errors_404(exception)
-    render json: exception, status: :not_found
+  def rescue_param_missing
+    render json: { errors: [exception.message] }, status: :forbidden
+  end
+
+  def record_not_found(exception)
+    render json: { errors: [exception.message] }, status: :not_found
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordInvalid, ActionController::ParameterMissing, with: :show_errors_403
+  rescue_from ActiveRecord::RecordNotFound, with: :show_errors_404
+
+  def show_errors_403(exception)
+    render json: exception, status: :forbidden
+  end
+
+  def show_errors_404(exception)
+    render json: exception, status: :not_found
+  end
 end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,0 +1,48 @@
+class LessonsController < ApplicationController
+  rescue_from ActiveRecord::RecordInvalid, ActionController::ParameterMissing, with: :show_errors_403
+  rescue_from ActiveRecord::RecordNotFound, with: :show_errors_404
+
+  before_action :set_lesson, only: %i[show update destroy]
+
+  def index
+    lessons = Lesson.all
+    render json: lessons, status: :ok
+  end
+
+  def create
+    this_lesson = Lesson.create!(lesson_params)
+    render json: this_lesson, status: :created
+  end
+
+  def show
+    render json: @this_lesson, status: :ok
+  end
+
+  def update
+    @this_lesson.update(lesson_params)
+    render json: @this_lesson, status: :ok
+  end
+
+  def destroy
+    @this_lesson.destroy
+    render status: :no_content
+  end
+
+  private
+
+  def set_lesson
+    @this_lesson = Lesson.find_by!(params.permit(:id))
+  end
+
+  def lesson_params
+    params.require(:lesson).permit(:title, :description)
+  end
+
+  def show_errors_403(exception)
+    render json: exception, status: :forbidden
+  end
+
+  def show_errors_404(exception)
+    render json: exception, status: :not_found
+  end
+end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,7 +1,4 @@
 class LessonsController < ApplicationController
-  rescue_from ActiveRecord::RecordInvalid, ActionController::ParameterMissing, with: :show_errors_403
-  rescue_from ActiveRecord::RecordNotFound, with: :show_errors_404
-
   before_action :set_lesson, only: %i[show update destroy]
 
   def index
@@ -36,13 +33,5 @@ class LessonsController < ApplicationController
 
   def lesson_params
     params.require(:lesson).permit(:title, :description)
-  end
-
-  def show_errors_403(exception)
-    render json: exception, status: :forbidden
-  end
-
-  def show_errors_404(exception)
-    render json: exception, status: :not_found
   end
 end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -22,7 +22,7 @@ class LessonsController < ApplicationController
 
   def destroy
     @this_lesson.destroy
-    render status: :no_content
+    head :no_content, status: :no_content
   end
 
   private

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -19,7 +19,7 @@ class LessonsController < ApplicationController
   end
 
   def update
-    @this_lesson.update(lesson_params)
+    @this_lesson.update!(lesson_params)
     render json: @this_lesson, status: :ok
   end
 

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -10,6 +10,6 @@
 #
 
 class Lesson < ApplicationRecord
-  validates :title, presence: true, length: { maximum: 50 }
+  validates :title, presence: true, allow_blank: false, length: { maximum: 50 }
   validates :description, length: { maximum: 300 }
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -10,6 +10,6 @@
 #
 
 class Lesson < ApplicationRecord
-  validates :title, presence: true, allow_blank: false, length: { maximum: 50 }
+  validates :title, presence: true, length: { maximum: 50 }
   validates :description, length: { maximum: 300 }
 end

--- a/app/serializers/lesson_serializer.rb
+++ b/app/serializers/lesson_serializer.rb
@@ -1,0 +1,3 @@
+class LessonSerializer < ActiveModel::Serializer
+  attributes :id
+end

--- a/app/serializers/lesson_serializer.rb
+++ b/app/serializers/lesson_serializer.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: lessons
+#
+#  id          :uuid             not null, primary key
+#  title       :string(50)       not null
+#  description :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 class LessonSerializer < ActiveModel::Serializer
-  attributes :id
+  attributes :id, :title, :description, :created_at
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :lessons, except: %i[new edit]
 end

--- a/doc/Lesson.postman_collection.json
+++ b/doc/Lesson.postman_collection.json
@@ -1,0 +1,1275 @@
+{
+	"info": {
+		"_postman_id": "8e4f36ec-7d3b-441f-8796-1b37ffe0f3d8",
+		"name": "Lesson",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Index",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {},
+				"url": {
+					"raw": "{{url}}/lessons",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"lessons"
+					]
+				}
+			},
+			"response": [
+				{
+					"id": "b83eb615-0a7e-4968-acc1-45ac38011549",
+					"name": "Index (good)",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"body": {},
+						"url": {
+							"raw": "{{url}}/lessons",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons"
+							]
+						}
+					},
+					"status": "OK ",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "max-age=0, private, must-revalidate",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "733",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 16:53:43 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Etag",
+							"value": "W/\"ce93205b2587308a8fa894b4aa3182ac\"",
+							"name": "Etag",
+							"description": "An identifier for a specific version of a resource, often a message digest"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "9c5bbc9e-970d-4c7b-bc49-5e0c5d898f30",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.004931",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "[{\"id\":\"3a59d6b5-c64e-4c6e-b8e1-fff9e5ffed14\",\"title\":\"my title\",\"description\":\"my description\",\"created_at\":\"2018-07-16T13:44:30.114Z\"},{\"id\":\"4c1d4fb7-fac3-4c9a-931a-892cca59a03f\",\"title\":\"my second title\",\"description\":\"my second description\",\"created_at\":\"2018-07-16T16:51:44.545Z\"},{\"id\":\"987b4dd9-369d-4612-b53c-c19e3283953b\",\"title\":\"my third title\",\"description\":\"my third description\",\"created_at\":\"2018-07-16T16:52:14.007Z\"},{\"id\":\"e4340e61-18f6-4916-a190-55255e7c72d6\",\"title\":\"my fourth title\",\"description\":\"my fourth description\",\"created_at\":\"2018-07-16T16:52:43.753Z\"},{\"id\":\"80b1d776-7279-46c3-96b1-2f072ad19913\",\"title\":\"my fifth title\",\"description\":\"my fifth description\",\"created_at\":\"2018-07-16T16:53:02.334Z\"}]"
+				}
+			]
+		},
+		{
+			"name": "Create",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"lesson\": {\n    \"title\": \"my third title\",\n    \"description\": \"my third description\"\n  }\n}"
+				},
+				"url": {
+					"raw": "{{url}}/lessons",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"lessons"
+					]
+				}
+			},
+			"response": [
+				{
+					"id": "0fd3f7b1-7bc8-45a8-abba-aef26992554d",
+					"name": "Create (bad : no params)",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": false
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{url}}/lessons",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons"
+							]
+						}
+					},
+					"status": "Forbidden ",
+					"code": 403,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "no-cache",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "48",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 16:59:03 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "84105ed1-f70a-4358-ae0d-d2f53befa2e3",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.028316",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "\"param is missing or the value is empty: lesson\""
+				},
+				{
+					"id": "e30be2be-f03e-4f44-beb0-5a31d818adaf",
+					"name": "Create (good)",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": false
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"lesson\": {\n    \"title\": \"my sixth title\",\n    \"description\": \"my sixth description\"\n  }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/lessons",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons"
+							]
+						}
+					},
+					"status": "Created ",
+					"code": 201,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "max-age=0, private, must-revalidate",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "147",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 16:55:11 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Etag",
+							"value": "W/\"e8a07443d8d8d84b56cb8b0eca79f292\"",
+							"name": "Etag",
+							"description": "An identifier for a specific version of a resource, often a message digest"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "61977fab-58e4-4b1e-bc6f-420966887a46",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.007309",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "{\"id\":\"2e4a143d-dbe4-4524-8771-66a8b01c9a81\",\"title\":\"my sixth title\",\"description\":\"my sixth description\",\"created_at\":\"2018-07-16T16:55:11.500Z\"}"
+				},
+				{
+					"id": "69dc44c0-5323-4b55-a13d-6324d3596737",
+					"name": "Create (bad : no title)",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": false
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"lesson\": {\n    \"title\": \"\",\n    \"description\": \"my seventh description\"\n  }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/lessons",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons"
+							]
+						}
+					},
+					"status": "Forbidden ",
+					"code": 403,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "no-cache",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "86",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 16:58:14 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "086117b2-aaa9-4201-b952-83f28302606c",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.038457",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "\"Validation failed: Title can't be blank, Title is too short (minimum is 1 character)\""
+				},
+				{
+					"id": "d2da0f8e-99bb-46b6-b115-e65948cff835",
+					"name": "Create (good without description)",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": false
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"lesson\": {\n    \"title\": \"my sixth title\",\n    \"description\": \"\"\n  }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/lessons",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons"
+							]
+						}
+					},
+					"status": "Created ",
+					"code": 201,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "max-age=0, private, must-revalidate",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "127",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 17:00:29 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Etag",
+							"value": "W/\"430e3d082a272893613394402efcdb89\"",
+							"name": "Etag",
+							"description": "An identifier for a specific version of a resource, often a message digest"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "1d2f15cc-ab6e-492e-8f3c-ec012c6d5e81",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.015676",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "{\"id\":\"7df643b4-ca5e-456c-8a44-9f3d907e8512\",\"title\":\"my sixth title\",\"description\":\"\",\"created_at\":\"2018-07-16T17:00:29.131Z\"}"
+				}
+			]
+		},
+		{
+			"name": "Show",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {},
+				"url": {
+					"raw": "{{url}}/lessons/1111",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"lessons",
+						"1111"
+					]
+				}
+			},
+			"response": [
+				{
+					"id": "19119d72-a406-46b2-ac35-97566a0438d5",
+					"name": "Show (bad : id doesn't exist)",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"body": {},
+						"url": {
+							"raw": "{{url}}/lessons/1111",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons",
+								"1111"
+							]
+						}
+					},
+					"status": "Not Found ",
+					"code": 404,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "no-cache",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "22",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 17:04:23 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "b0c8dc06-7618-4571-af12-f6f2218a405b",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.006262",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "\"Couldn't find Lesson\""
+				},
+				{
+					"id": "54788717-960d-453d-81f8-88534e7edaca",
+					"name": "Show (good)",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"body": {},
+						"url": {
+							"raw": "{{url}}/lessons/7df643b4-ca5e-456c-8a44-9f3d907e8512",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons",
+								"7df643b4-ca5e-456c-8a44-9f3d907e8512"
+							]
+						}
+					},
+					"status": "OK ",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "max-age=0, private, must-revalidate",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "127",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 17:02:38 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Etag",
+							"value": "W/\"430e3d082a272893613394402efcdb89\"",
+							"name": "Etag",
+							"description": "An identifier for a specific version of a resource, often a message digest"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "1a487915-f6d7-4195-9abd-9694ffb9f41c",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.018877",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "{\"id\":\"7df643b4-ca5e-456c-8a44-9f3d907e8512\",\"title\":\"my sixth title\",\"description\":\"\",\"created_at\":\"2018-07-16T17:00:29.131Z\"}"
+				}
+			]
+		},
+		{
+			"name": "Update",
+			"request": {
+				"method": "PUT",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"lesson\": {\n\t\"title\": \"\"\n  }\n}"
+				},
+				"url": {
+					"raw": "{{url}}/lessons/7df643b4-ca5e-456c-8a44-9f3d907e8512",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"lessons",
+						"7df643b4-ca5e-456c-8a44-9f3d907e8512"
+					]
+				}
+			},
+			"response": [
+				{
+					"id": "e6ccc249-9066-4f2e-b174-a74eab17247c",
+					"name": "Update (bad : no title)",
+					"originalRequest": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": false
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"lesson\": {\n\t\"title\": \"\"\n  }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/lessons/7df643b4-ca5e-456c-8a44-9f3d907e8512",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons",
+								"7df643b4-ca5e-456c-8a44-9f3d907e8512"
+							]
+						}
+					},
+					"status": "Forbidden ",
+					"code": 403,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "no-cache",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "86",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 17:17:05 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "56c978b6-3703-4a17-81c3-d043b0d31e24",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.009335",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "\"Validation failed: Title can't be blank, Title is too short (minimum is 1 character)\""
+				},
+				{
+					"id": "641915d0-edff-40ff-9796-35ee7e8c51f6",
+					"name": "Update (good)",
+					"originalRequest": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": false
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"lesson\": {\n    \"title\": \"my new title\",\n    \"description\": \"my description\"\n  }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/lessons/7df643b4-ca5e-456c-8a44-9f3d907e8512",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons",
+								"7df643b4-ca5e-456c-8a44-9f3d907e8512"
+							]
+						}
+					},
+					"status": "OK ",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "max-age=0, private, must-revalidate",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "139",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 17:08:07 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Etag",
+							"value": "W/\"9a85751b67687df52fc5d8c0de535520\"",
+							"name": "Etag",
+							"description": "An identifier for a specific version of a resource, often a message digest"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "1d678a53-0616-4c28-b68f-434b7411a4af",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.013635",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "{\"id\":\"7df643b4-ca5e-456c-8a44-9f3d907e8512\",\"title\":\"my new title\",\"description\":\"my description\",\"created_at\":\"2018-07-16T17:00:29.131Z\"}"
+				},
+				{
+					"id": "41c5ebfb-8d12-45f0-bb52-03571be87d5d",
+					"name": "Update (bad : no params)",
+					"originalRequest": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": false
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n}"
+						},
+						"url": {
+							"raw": "{{url}}/lessons/7df643b4-ca5e-456c-8a44-9f3d907e8512",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons",
+								"7df643b4-ca5e-456c-8a44-9f3d907e8512"
+							]
+						}
+					},
+					"status": "Forbidden ",
+					"code": 403,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "no-cache",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "48",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 17:15:51 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "9ea291aa-b9be-489e-8f2b-cca2a0104c80",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.014590",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "\"param is missing or the value is empty: lesson\""
+				},
+				{
+					"id": "5d69c109-a7b7-45b0-86c8-18bb20cd8a6e",
+					"name": "Update (good : just title)",
+					"originalRequest": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": false
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"lesson\": {\n    \"title\": \"my new title\",\n    \"description\": \"\"\n  }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/lessons/7df643b4-ca5e-456c-8a44-9f3d907e8512",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons",
+								"7df643b4-ca5e-456c-8a44-9f3d907e8512"
+							]
+						}
+					},
+					"status": "OK ",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "max-age=0, private, must-revalidate",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "125",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 17:08:44 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Etag",
+							"value": "W/\"16b933a456fb46725429ac399b54f658\"",
+							"name": "Etag",
+							"description": "An identifier for a specific version of a resource, often a message digest"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "1d6b74e9-8364-4aa6-8ecf-ff875342c5a6",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.012566",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "{\"id\":\"7df643b4-ca5e-456c-8a44-9f3d907e8512\",\"title\":\"my new title\",\"description\":\"\",\"created_at\":\"2018-07-16T17:00:29.131Z\"}"
+				},
+				{
+					"id": "97fbfc28-1f75-4e68-92ad-cf9d24b26262",
+					"name": "Update (good : just description)",
+					"originalRequest": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"disabled": false
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"lesson\": {\n\t\"description\": \"a other description\"\n  }\n}"
+						},
+						"url": {
+							"raw": "{{url}}/lessons/7df643b4-ca5e-456c-8a44-9f3d907e8512",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons",
+								"7df643b4-ca5e-456c-8a44-9f3d907e8512"
+							]
+						}
+					},
+					"status": "OK ",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "max-age=0, private, must-revalidate",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "147",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 17:11:47 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Etag",
+							"value": "W/\"5e54b12d97fa5f5f4a43ff803f0b2753\"",
+							"name": "Etag",
+							"description": "An identifier for a specific version of a resource, often a message digest"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "7292f410-ec9a-4ab8-b7da-6e6bb5cdbb90",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.020537",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "{\"id\":\"7df643b4-ca5e-456c-8a44-9f3d907e8512\",\"title\":\"the sixth title\",\"description\":\"a other description\",\"created_at\":\"2018-07-16T17:00:29.131Z\"}"
+				}
+			]
+		},
+		{
+			"name": "Delete",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"body": {},
+				"url": {
+					"raw": "localhost:3000/lessons/c87f7ec6-269f-4e10-a19b-f8ff62c867d0",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"lessons",
+						"c87f7ec6-269f-4e10-a19b-f8ff62c867d0"
+					]
+				}
+			},
+			"response": [
+				{
+					"id": "d2db08ef-9f9b-4e58-b3f7-f2f2544b7cc9",
+					"name": "Delete (bad : id doesn't exist)",
+					"originalRequest": {
+						"method": "DELETE",
+						"header": [],
+						"body": {},
+						"url": {
+							"raw": "{{url}}/lessons/1111",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons",
+								"1111"
+							]
+						}
+					},
+					"status": "Not Found ",
+					"code": 404,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "no-cache",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Content-Length",
+							"value": "22",
+							"name": "Content-Length",
+							"description": "The length of the response body in octets (8-bit bytes)"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8",
+							"name": "Content-Type",
+							"description": "The mime type of this content"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 17:27:04 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "185bfa83-99e4-46f6-b19f-98d74b383d37",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.006365",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": "\"Couldn't find Lesson\""
+				},
+				{
+					"id": "76d583a5-ef7e-4019-aa65-b39539f12be4",
+					"name": "Delete (good)",
+					"originalRequest": {
+						"method": "DELETE",
+						"header": [],
+						"body": {},
+						"url": {
+							"raw": "{{url}}/lessons/7df643b4-ca5e-456c-8a44-9f3d907e8512",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"lessons",
+								"7df643b4-ca5e-456c-8a44-9f3d907e8512"
+							]
+						}
+					},
+					"status": "No Content ",
+					"code": 204,
+					"_postman_previewlanguage": "plain",
+					"header": [
+						{
+							"key": "Cache-Control",
+							"value": "no-cache",
+							"name": "Cache-Control",
+							"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+						},
+						{
+							"key": "Connection",
+							"value": "Keep-Alive",
+							"name": "Connection",
+							"description": "Options that are desired for the connection"
+						},
+						{
+							"key": "Date",
+							"value": "Mon, 16 Jul 2018 17:26:45 GMT",
+							"name": "Date",
+							"description": "The date and time that the message was sent"
+						},
+						{
+							"key": "Server",
+							"value": "WEBrick/1.4.2 (Ruby/2.5.1/2018-03-29)",
+							"name": "Server",
+							"description": "A name for the server"
+						},
+						{
+							"key": "X-Request-Id",
+							"value": "75035a79-8b18-4ecd-9ac0-fc35031bc6b3",
+							"name": "X-Request-Id",
+							"description": "Custom header"
+						},
+						{
+							"key": "X-Runtime",
+							"value": "0.017880",
+							"name": "X-Runtime",
+							"description": "Custom header"
+						}
+					],
+					"cookie": [],
+					"body": ""
+				}
+			]
+		}
+	],
+	"variable": [
+		{
+			"id": "685fa81e-8f51-4b9e-b24d-b67c55cb7e30",
+			"key": "adress",
+			"value": "localhost:3000",
+			"type": "string",
+			"description": ""
+		}
+	]
+}

--- a/spec/controllers/lesson_controller_spec.rb
+++ b/spec/controllers/lesson_controller_spec.rb
@@ -73,22 +73,38 @@ RSpec.describe LessonsController, type: :controller do
     end
 
     context 'with invalid params' do
-      before{ lesson_params[:title] = '' }
       it 'returns status 403 without title' do
+        lesson_params[:title] = ''
         subject
         expect(response.code).to eq("403")
       end
       it 'doesn\'t create new lesson' do
+        lesson_params[:title] = ''
         expect{ subject }.to change { Lesson.count }.by(0)
+      end
+      it 'returns status 403 with title so long' do
+        lesson_params[:title] = Faker::Lorem.characters(51)
+        subject
+        expect(response.code).to eq("403")
+      end
+      it 'returns status 403 with description so long' do
+        lesson_params[:description] = Faker::Lorem.characters(301)
+        subject
+        expect(response.code).to eq("403")
+      end
+      it 'returns status 403 with no title' do
+        lesson_params[:title] = ''
+        subject
+        expect(response.code).to eq("403")
       end
     end
   end
 
   describe 'POST #update' do
     let(:lesson) { FactoryBot.create(:lesson, title: 'Arthus') }
-    let(:new_title){ 'Harry' }
+    let(:new_params){ FactoryBot.attributes_for(:lesson).merge(title: 'Harry') }
 
-    subject{ post :update, params: { id: lesson.id, lesson: { title: new_title } } }
+    subject{ post :update, params: { id: lesson.id, lesson: new_params } }
 
     context 'with valid params' do
       before{ subject }
@@ -96,15 +112,30 @@ RSpec.describe LessonsController, type: :controller do
         expect(response.code).to eq("200")
       end
       it 'changes the title' do
-        expect(json_response[:title]).to eq(new_title)
+        expect(json_response[:title]).to eq(new_params[:title])
       end
     end
 
     context 'with invalid params' do
-      let(:new_title){ '' }
-      it 'returns status 403' do
+      it 'returns status 403 without title' do
+        new_params[:title] = ''
         subject
-        expect(response.code).to eq('403')
+        expect(response.code).to eq("403")
+      end
+      it 'returns status 403 with title so long' do
+        new_params[:title] = Faker::Lorem.characters(51)
+        subject
+        expect(response.code).to eq("403")
+      end
+      it 'returns status 403 with description so long' do
+        new_params[:description] = Faker::Lorem.characters(301)
+        subject
+        expect(response.code).to eq("403")
+      end
+      it 'returns status 403 with no title' do
+        new_params[:title] = ''
+        subject
+        expect(response.code).to eq("403")
       end
     end
   end

--- a/spec/controllers/lesson_controller_spec.rb
+++ b/spec/controllers/lesson_controller_spec.rb
@@ -1,6 +1,3 @@
-require 'rails_helper'
-require 'pry'
-
 RSpec.describe LessonsController, type: :controller do
   describe 'routes' do
     it { should route(:get, '/lessons').to(action: :index) }
@@ -17,12 +14,12 @@ RSpec.describe LessonsController, type: :controller do
     end
 
     before do
-      FactoryBot.create_list(:lesson, 2)
+      create_list(:lesson, 2)
       subject
     end
 
     it 'returns status 200' do
-      expect(response.code).to eq("200")
+      expect(response).to have_http_status(:ok)
     end
 
     it 'lists 2 lessons' do
@@ -31,40 +28,38 @@ RSpec.describe LessonsController, type: :controller do
   end
 
   describe 'GET #show' do
-    let!(:lesson){ FactoryBot.create(:lesson) }
-    let(:id){ Lesson.last.id }
+    let(:lesson_id){ create(:lesson).id }
 
-    subject{ get :show, params: { id: id } }
+    subject{ get :show, params: { id: lesson_id } }
 
     context 'when lesson exist' do
+      before { subject }
       it 'returns status 200' do
-        subject
-        expect(response.code).to eq("200")
+        expect(response).to have_http_status(:ok)
       end
       it "shows the lesson" do
-        subject
-        expect(json_response[:id]).to eq(lesson.id)
+        expect(json_response[:id]).to eq(lesson_id)
       end
     end
 
     context 'when lesson doesn\'t exist' do
-      let(:id){ 1 }
+      let(:lesson_id){ 1 }
       it "returns error 404" do
         subject
-        expect(response.code).to eq("404")
+        expect(response).to have_http_status(:not_found)
       end
     end
   end
 
   describe 'POST #create' do
-    let(:lesson_params){ FactoryBot.attributes_for(:lesson) }
+    let(:lesson_params){ attributes_for(:lesson) }
 
     subject{ post :create, params: { lesson: lesson_params } }
 
     context 'with valid params' do
       it 'returns status 201' do
         subject
-        expect(response.code).to eq("201")
+        expect(response).to have_http_status(:created)
       end
 
       it 'creates new lesson' do
@@ -76,40 +71,40 @@ RSpec.describe LessonsController, type: :controller do
       it 'returns status 403 without title' do
         lesson_params[:title] = ''
         subject
-        expect(response.code).to eq("403")
+        expect(response).to have_http_status(:forbidden)
       end
       it 'doesn\'t create new lesson' do
         lesson_params[:title] = ''
-        expect{ subject }.to change { Lesson.count }.by(0)
+        expect{ subject }.to_not(change{ Lesson.count })
       end
       it 'returns status 403 with title so long' do
         lesson_params[:title] = Faker::Lorem.characters(51)
         subject
-        expect(response.code).to eq("403")
+        expect(response).to have_http_status(:forbidden)
       end
       it 'returns status 403 with description so long' do
         lesson_params[:description] = Faker::Lorem.characters(301)
         subject
-        expect(response.code).to eq("403")
+        expect(response).to have_http_status(:forbidden)
       end
       it 'returns status 403 with no title' do
         lesson_params[:title] = ''
         subject
-        expect(response.code).to eq("403")
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
 
   describe 'POST #update' do
-    let(:lesson) { FactoryBot.create(:lesson, title: 'Arthus') }
-    let(:new_params){ FactoryBot.attributes_for(:lesson).merge(title: 'Harry') }
+    let(:lesson) { create(:lesson, title: 'Arthus') }
+    let(:new_params){ attributes_for(:lesson).merge(title: 'Harry') }
 
     subject{ post :update, params: { id: lesson.id, lesson: new_params } }
 
     context 'with valid params' do
       before{ subject }
       it 'returns status 200' do
-        expect(response.code).to eq("200")
+        expect(response).to have_http_status(:ok)
       end
       it 'changes the title' do
         expect(json_response[:title]).to eq(new_params[:title])
@@ -120,35 +115,35 @@ RSpec.describe LessonsController, type: :controller do
       it 'returns status 403 without title' do
         new_params[:title] = ''
         subject
-        expect(response.code).to eq("403")
+        expect(response).to have_http_status(:forbidden)
       end
       it 'returns status 403 with title so long' do
         new_params[:title] = Faker::Lorem.characters(51)
         subject
-        expect(response.code).to eq("403")
+        expect(response).to have_http_status(:forbidden)
       end
       it 'returns status 403 with description so long' do
         new_params[:description] = Faker::Lorem.characters(301)
         subject
-        expect(response.code).to eq("403")
+        expect(response).to have_http_status(:forbidden)
       end
       it 'returns status 403 with no title' do
         new_params[:title] = ''
         subject
-        expect(response.code).to eq("403")
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end
 
   describe 'DELETE #destroy' do
-    let!(:lesson_id){ FactoryBot.create(:lesson).id }
+    let!(:lesson_id){ create(:lesson).id }
 
     subject{ delete :destroy, params: { id: lesson_id } }
 
     context 'with valid params' do
       it 'returns status 204' do
         subject
-        expect(response.code).to eq('204')
+        expect(response).to have_http_status(:no_content)
       end
       it 'destroys the lesson' do
         expect{ subject }.to change{ Lesson.count }.by(-1)
@@ -160,10 +155,10 @@ RSpec.describe LessonsController, type: :controller do
 
       it 'returns status 404' do
         subject
-        expect(response.code).to eq('404')
+        expect(response).to have_http_status(:not_found)
       end
       it 'doesn\'t destroy the lesson' do
-        expect{ subject }.to change{ Lesson.count }.by(0)
+        expect{ subject }.to_not(change{ Lesson.count })
       end
     end
   end

--- a/spec/controllers/lesson_controller_spec.rb
+++ b/spec/controllers/lesson_controller_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+require 'pry'
+
+RSpec.describe LessonsController, type: :controller do
+  describe 'routes' do
+    it { should route(:get, '/lessons').to(action: :index) }
+    it { should route(:get, '/lessons/574d5c29-fd2d-4494-ae28-12cdb0da1c07').to(action: :show, id: "574d5c29-fd2d-4494-ae28-12cdb0da1c07") }
+    it { should route(:post, '/lessons').to(action: :create) }
+    it { should route(:put, '/lessons/574d5c29-fd2d-4494-ae28-12cdb0da1c07').to(action: :update, id: "574d5c29-fd2d-4494-ae28-12cdb0da1c07") }
+    it { should route(:patch, '/lessons/574d5c29-fd2d-4494-ae28-12cdb0da1c07').to(action: :update, id: "574d5c29-fd2d-4494-ae28-12cdb0da1c07") }
+    it { should route(:delete, '/lessons/574d5c29-fd2d-4494-ae28-12cdb0da1c07').to(action: :destroy, id: "574d5c29-fd2d-4494-ae28-12cdb0da1c07") }
+  end
+
+  describe 'GET #index' do
+    subject do
+      get :index
+    end
+
+    before do
+      FactoryBot.create_list(:lesson, 2)
+      subject
+    end
+
+    it 'returns status 200' do
+      expect(response.code).to eq("200")
+    end
+
+    it 'lists 2 lessons' do
+      expect(json_response.count).to eq(2)
+    end
+  end
+
+  describe 'GET #show' do
+    let!(:lesson){ FactoryBot.create(:lesson) }
+    let(:id){ Lesson.last.id }
+
+    subject{ get :show, params: { id: id } }
+
+    context 'when lesson exist' do
+      it 'returns status 200' do
+        subject
+        expect(response.code).to eq("200")
+      end
+      it "shows the lesson" do
+        subject
+        expect(json_response[:id]).to eq(lesson.id)
+      end
+    end
+
+    context 'when lesson doesn\'t exist' do
+      let(:id){ 1 }
+      it "returns error 404" do
+        subject
+        expect(response.code).to eq("404")
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    let(:lesson_params){ FactoryBot.attributes_for(:lesson) }
+
+    subject{ post :create, params: { lesson: lesson_params } }
+
+    context 'with valid params' do
+      it 'returns status 201' do
+        subject
+        expect(response.code).to eq("201")
+      end
+
+      it 'creates new lesson' do
+        expect{ subject }.to change{ Lesson.count }.by(1)
+      end
+    end
+
+    context 'with invalid params' do
+      before{ lesson_params[:title] = '' }
+      it 'returns status 403 without title' do
+        subject
+        expect(response.code).to eq("403")
+      end
+      it 'doesn\'t create new lesson' do
+        expect{ subject }.to change { Lesson.count }.by(0)
+      end
+    end
+  end
+
+  describe 'POST #update' do
+    let(:lesson) { FactoryBot.create(:lesson, title: 'Arthus') }
+    let(:new_title){ 'Harry' }
+
+    subject{ post :update, params: { id: lesson.id, lesson: { title: new_title } } }
+
+    context 'with valid params' do
+      before{ subject }
+      it 'returns status 200' do
+        expect(response.code).to eq("200")
+      end
+      it 'changes the title' do
+        expect(json_response[:title]).to eq(new_title)
+      end
+    end
+
+    context 'with invalid params' do
+      let(:new_title){ '' }
+      it 'returns status 403' do
+        subject
+        expect(response.code).to eq('403')
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    let!(:lesson_id){ FactoryBot.create(:lesson).id }
+
+    subject{ delete :destroy, params: { id: lesson_id } }
+
+    context 'with valid params' do
+      it 'returns status 204' do
+        subject
+        expect(response.code).to eq('204')
+      end
+      it 'destroys the lesson' do
+        expect{ subject }.to change{ Lesson.count }.by(-1)
+      end
+    end
+
+    context 'with invalid params' do
+      let!(:lesson_id) { 1 }
+
+      it 'returns status 404' do
+        subject
+        expect(response.code).to eq('404')
+      end
+      it 'doesn\'t destroy the lesson' do
+        expect{ subject }.to change{ Lesson.count }.by(0)
+      end
+    end
+  end
+end

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -13,7 +13,7 @@ require 'faker'
 
 FactoryBot.define do
   factory :lesson do
-    title Faker::Hacker.noun.first(50)
-    description Faker::ChuckNorris.fact.first(300)
+    title { Faker::Hacker.noun.first(50) }
+    description { Faker::ChuckNorris.fact.first(300) }
   end
 end

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Lesson, type: :model do
   end
 
   it "is valid with no description" do
-    expect(build(:lesson, description: "")).to be_valid
+    expect(build(:lesson, description: nil)).to be_valid
   end
 
   it "is saved with valid attributes" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ require 'support/factory_bot'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -55,6 +55,9 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Custom
+  config.include JsonHelper
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ require 'support/factory_bot'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/json_helper.rb
+++ b/spec/support/json_helper.rb
@@ -1,0 +1,9 @@
+module JsonHelper
+  def json_response
+    if (json = JSON.parse(response.body)).is_a?(Array)
+      json.map!(&:with_indifferent_access)
+    else
+      json.with_indifferent_access
+    end
+  end
+end


### PR DESCRIPTION
# Controller

### Serializer : 
Add Serializer gem in Gemfile : 
```
## Serializer
gem 'active_model_serializers', '~> 0.10.0
```
Then, `bundle install`
Generating the serializer for lesson model : `rails g serializer lesson`
After that, you can specify attributes you want render : 
```
attributes :id, :title, :description, :created_at
```
Now, it's easy because we have no association. 

## Routes
We use the keyword ressources in the `route.rb` file : 
``` 
resources :lessons, except: [:new, :edit]
```
Testing the last step with `rails routes`

## Controller 
Create a controller with [this ressource](http://api.rubyonrails.org/classes/ActionController/API.html). As read, ApplicationController is the right controller for API. 

### Error : 
We want that an error raises up when params aren't valid. `create!()` permit that : if validation doesn't work, `ActiveRecord::RecordInvalid: Validation failed:` raises. Place that in `application.rb` file : 
```
  # Two errors catched : RecordInvalid and ParameterMissing
  rescue_from ActiveRecord::RecordInvalid, ActionController::ParameterMissing, with: :show_errors

  def show_errors(exception)
    render json: exception, status: 403
  end
```

### Render :
To return, use `render json: object, status number`. 
Replace with the correct object who has a serializer. Add the correspondent status (the number or the name). 

## Test controller : 
Some tips : 
- creating some lessons with `FactoryBot.create_list(:lesson, 2)`. But to test index method, no need creates few dozens of lessons. Just two are sufficient. 
- `it { should route(:get, '/lessons').to(action: :index) }` to test each route with the url and the name of method in the controller. 
- `expect(response.code).to eq("200")` to test the response code.
- use variables with let (lazy utilisation) and let! (behavior like `before`)
- use `subject`
- describing with keywords `describe` which contains `context` 's


Closes #9 